### PR TITLE
Make card click reveal answer and expand font sizes

### DIFF
--- a/cards.html
+++ b/cards.html
@@ -47,6 +47,7 @@
     border-radius: var(--radius); box-shadow: var(--shadow);
     padding: 28px 18px; min-height: 280px; display: grid; align-content: center; gap: 12px; text-align: center;
     touch-action: manipulation;
+    cursor: pointer;
   }
   /* Removed side labels per request */
   .front { font-size: var(--fs-front); font-weight: 700; line-height: 1.15; word-break: break-word; }
@@ -121,9 +122,6 @@
     <div class="row equal">
       <button id="btnPrev" title="Назад (←)" aria-label="Назад">←</button>
       <button id="btnNext" title="Вперёд (→)" aria-label="Вперёд">→</button>
-    </div>
-    <div class="row">
-      <button class="primary" id="btnFlip" title="Показать/скрыть ответ (Пробел)" aria-label="Показать ответ">Показать ответ</button>
     </div>
     <!-- Know/Don't know row: equal-sized buttons -->
     <div class="row equal">
@@ -208,12 +206,10 @@ const verdict = new Array(CARDS.length).fill(null);
  *  ШРИФТ — управление и сохранение
  *  ======================== */
 const FONT_KEY = "flashcards_font_scale_v1";
-const FONT_STEPS = [
-  { front: "28px", back: "18px" },
-  { front: "32px", back: "20px" },
-  { front: "36px", back: "22px" },
-  { front: "40px", back: "24px" }
-];
+const FONT_STEPS = Array.from({length: 12}, (_, i) => ({
+  front: `${28 + i*4}px`,
+  back: `${18 + i*2}px`
+}));
 let fontIndex = 1;
 function applyFontStep(i){
   fontIndex = Math.max(0, Math.min(FONT_STEPS.length-1, i));
@@ -263,9 +259,7 @@ function render(){
 
   if(browse){
     backText.style.display = "none";
-    document.getElementById("btnFlip").disabled = true;
   } else {
-    document.getElementById("btnFlip").disabled = false;
     backText.style.display = (side === "back") ? "block" : "none";
   }
   recountStats();
@@ -306,7 +300,7 @@ function shuffle(){
  *  ======================== */
 document.getElementById("btnPrev").addEventListener("click", () => go(-1));
 document.getElementById("btnNext").addEventListener("click", () => go(1));
-document.getElementById("btnFlip").addEventListener("click", flip);
+document.getElementById("card").addEventListener("click", flip);
 document.getElementById("btnKnow").addEventListener("click", () => setVerdict("known"));
 document.getElementById("btnDontKnow").addEventListener("click", () => setVerdict("unknown"));
 document.getElementById("btnReset").addEventListener("click", resetStats);


### PR DESCRIPTION
## Summary
- Allow clicking the card to flip the answer instead of relying on a button
- Extend font scaling with more steps for larger text
- Indicate card interactivity via a pointer cursor

## Testing
- `npx --yes htmlhint cards.html` *(fails: 403 Forbidden)*
- `node --check temp.js`


------
https://chatgpt.com/codex/tasks/task_e_68a198f0245c83228a5b26e16bae08b6