### PR TITLE
Advance cards on answer and show completion toast

### DIFF
--- a/cards.html
+++ b/cards.html
@@ -47,6 +47,7 @@
     border-radius: var(--radius); box-shadow: var(--shadow);
     padding: 28px 18px; min-height: 280px; display: grid; align-content: center; gap: 12px; text-align: center;
     touch-action: manipulation;
+    cursor: pointer;
   }
   /* Removed side labels per request */
   .front { font-size: var(--fs-front); font-weight: 700; line-height: 1.15; word-break: break-word; }
@@ -72,6 +73,20 @@
   .seg { display: inline-flex; border-radius: 999px; overflow: hidden; box-shadow: var(--shadow); }
   .seg button { background: var(--ghost); border-radius: 0; }
   .seg button + button { border-left: 1px solid rgba(255,255,255,0.08); }
+
+  .toast {
+    position: fixed;
+    bottom: 20px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--panel);
+    color: var(--text);
+    padding: 10px 18px;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow);
+    display: none;
+    z-index: 1000;
+  }
 
   footer { color: var(--muted); font-size: var(--fs-micro); text-align: center; padding: 6px; }
   @media (min-width: 700px) {
@@ -122,9 +137,6 @@
       <button id="btnPrev" title="Назад (←)" aria-label="Назад">←</button>
       <button id="btnNext" title="Вперёд (→)" aria-label="Вперёд">→</button>
     </div>
-    <div class="row">
-      <button class="primary" id="btnFlip" title="Показать/скрыть ответ (Пробел)" aria-label="Показать ответ">Показать ответ</button>
-    </div>
     <!-- Know/Don't know row: equal-sized buttons -->
     <div class="row equal">
       <button class="success" id="btnKnow" title="Отметить как Знаю (K)" aria-label="Знаю">Знаю</button>
@@ -137,6 +149,8 @@
 
   <footer>Данные карточек — внизу файла (массив CARDS). Цветовая схема — высококонтрастная, без «жёсткого» белого, для комфортного запоминания.</footer>
 </div>
+
+<div id="toast" class="toast"></div>
 
 <script>
 /** ========================
@@ -208,12 +222,10 @@ const verdict = new Array(CARDS.length).fill(null);
  *  ШРИФТ — управление и сохранение
  *  ======================== */
 const FONT_KEY = "flashcards_font_scale_v1";
-const FONT_STEPS = [
-  { front: "28px", back: "18px" },
-  { front: "32px", back: "20px" },
-  { front: "36px", back: "22px" },
-  { front: "40px", back: "24px" }
-];
+const FONT_STEPS = Array.from({length: 12}, (_, i) => ({
+  front: `${28 + i*4}px`,
+  back: `${18 + i*2}px`
+}));
 let fontIndex = 1;
 function applyFontStep(i){
   fontIndex = Math.max(0, Math.min(FONT_STEPS.length-1, i));
@@ -263,9 +275,7 @@ function render(){
 
   if(browse){
     backText.style.display = "none";
-    document.getElementById("btnFlip").disabled = true;
   } else {
-    document.getElementById("btnFlip").disabled = false;
     backText.style.display = (side === "back") ? "block" : "none";
   }
   recountStats();
@@ -301,14 +311,33 @@ function shuffle(){
   render();
 }
 
+function showToast(msg){
+  const t = document.getElementById("toast");
+  t.textContent = msg;
+  t.style.display = "block";
+  setTimeout(() => { t.style.display = "none"; }, 2000);
+}
+
+function respond(kind){
+  setVerdict(kind);
+  if(idx >= order.length - 1){
+    idx = 0;
+    side = "front";
+    render();
+    showToast("Список закончен");
+  } else {
+    go(1);
+  }
+}
+
 /** ========================
  *  СВЯЗЬ С UI
  *  ======================== */
 document.getElementById("btnPrev").addEventListener("click", () => go(-1));
 document.getElementById("btnNext").addEventListener("click", () => go(1));
-document.getElementById("btnFlip").addEventListener("click", flip);
-document.getElementById("btnKnow").addEventListener("click", () => setVerdict("known"));
-document.getElementById("btnDontKnow").addEventListener("click", () => setVerdict("unknown"));
+document.getElementById("card").addEventListener("click", flip);
+document.getElementById("btnKnow").addEventListener("click", () => respond("known"));
+document.getElementById("btnDontKnow").addEventListener("click", () => respond("unknown"));
 document.getElementById("btnReset").addEventListener("click", resetStats);
 document.getElementById("btnShuffle").addEventListener("click", shuffle);
 document.getElementById("toggleBrowse").addEventListener("change", render);
@@ -323,8 +352,8 @@ window.addEventListener("keydown", (e) => {
   if(e.key === "ArrowLeft"){ e.preventDefault(); go(-1); }
   else if(e.key === "ArrowRight"){ e.preventDefault(); go(1); }
   else if(e.key === " "){ e.preventDefault(); flip(); }
-  else if(e.key.toLowerCase() === "k"){ e.preventDefault(); setVerdict("known"); }
-  else if(e.key.toLowerCase() === "n"){ e.preventDefault(); setVerdict("unknown"); }
+  else if(e.key.toLowerCase() === "k"){ e.preventDefault(); respond("known"); }
+  else if(e.key.toLowerCase() === "n"){ e.preventDefault(); respond("unknown"); }
   else if(e.key.toLowerCase() === "r"){ e.preventDefault(); resetStats(); }
 });
 


### PR DESCRIPTION
## Summary
- Automatically flip to the next card when marking "Знаю" or "Не знаю"
- Wrap back to the first card with a short toast when the list is finished
- Provide toast styling and keyboard shortcuts aligned with the new flow

## Testing
- `npx --yes htmlhint cards.html` *(fails: 403 Forbidden)*
- `node --check temp.js && echo syntax OK`


------
https://chatgpt.com/codex/tasks/task_e_68a198f0245c83228a5b26e16bae08b6