### PR TITLE
Add reverse flashcard option and remove file hints

### DIFF
--- a/adverbs.html
+++ b/adverbs.html
@@ -89,7 +89,6 @@
     z-index: 1000;
   }
 
-  footer { color: var(--muted); font-size: var(--fs-micro); text-align: center; padding: 6px; }
   @media (min-width: 700px) {
     .controls { grid-template-columns: 1fr 1fr 1fr; }
     .controls > .row:nth-child(1) { grid-column: 1 / -1; } /* arrows row spans full width */
@@ -113,6 +112,7 @@
       <div class="muted">Режим: <b id="modeText">Обычный</b></div>
     </div>
     <div class="toggles">
+      <label class="switch"><input id="toggleReverse" type="checkbox"><span>Перевод первым</span></label>
       <label class="switch"><input id="toggleBrowse" type="checkbox"><span>Пролистывание</span></label>
       <div class="seg" aria-label="Размер шрифта">
         <button id="fontDec" title="Уменьшить шрифт" aria-label="Уменьшить шрифт">A−</button>
@@ -150,7 +150,6 @@
     </div>
   </nav>
 
-  <footer>Данные карточек — в отдельном файле <code>cards/adverbs.js</code>. Цветовая схема — высококонтрастная, без «жёсткого» белого, для комфортного запоминания.</footer>
 </div>
 
 <div id="toast" class="toast"></div>

--- a/bundle.js
+++ b/bundle.js
@@ -92,8 +92,6 @@ function renderMenu(){
         <li><a href="pronouns.html" style="font-weight:700; font-size:1.15rem; text-decoration:none; color:inherit;">Польские местоимения</a></li>
       </ul>
     </section>
-    <hr />
-    <small>Добавьте свои подборки в папку <code>/sets</code> и зарегистрируйте их в <code>sets/index.js</code></small>
   `;
 
   app.querySelectorAll('a[data-set]').forEach(link => {

--- a/flashcards.js
+++ b/flashcards.js
@@ -50,6 +50,7 @@ function render(){
   const hintText = document.getElementById("hintText");
   const modeText = document.getElementById("modeText");
   const browse = document.getElementById("toggleBrowse").checked;
+  const reverse = document.getElementById("toggleReverse").checked;
   modeText.textContent = browse ? "Пролистывание" : "Обычный";
 
   if(order.length === 0){
@@ -62,8 +63,10 @@ function render(){
   const card = CARDS[ order[idx] ];
   // Всегда показываем фронт при входе в карточку
   side = "front";
-  frontText.textContent = card.front;
-  backText.textContent = card.back;
+  const frontContent = reverse ? card.back : card.front;
+  const backContent  = reverse ? card.front : card.back;
+  frontText.textContent = frontContent;
+  backText.textContent = backContent;
   hintText.textContent = card.hint || "";
 
   if(browse){
@@ -141,6 +144,7 @@ document.getElementById("btnDontKnow").addEventListener("click", () => respond("
 document.getElementById("btnReset").addEventListener("click", resetStats);
 document.getElementById("btnShuffle").addEventListener("click", shuffle);
 document.getElementById("toggleBrowse").addEventListener("change", render);
+document.getElementById("toggleReverse").addEventListener("change", render);
 document.getElementById("fontInc").addEventListener("click", () => applyFontStep(fontIndex + 1));
 document.getElementById("fontDec").addEventListener("click", () => applyFontStep(fontIndex - 1));
 document.getElementById("fontReset").addEventListener("click", () => applyFontStep(1));

--- a/main.js
+++ b/main.js
@@ -92,8 +92,6 @@ function renderMenu(){
         <li><a href="pronouns.html" style="font-weight:700; font-size:1.15rem; text-decoration:none; color:inherit;">Польские местоимения</a></li>
       </ul>
     </section>
-    <hr />
-    <small>Добавьте свои подборки в папку <code>/sets</code> и зарегистрируйте их в <code>sets/index.js</code></small>
   `;
 
   app.querySelectorAll('a[data-set]').forEach(link => {

--- a/pronouns.html
+++ b/pronouns.html
@@ -89,7 +89,6 @@
     z-index: 1000;
   }
 
-  footer { color: var(--muted); font-size: var(--fs-micro); text-align: center; padding: 6px; }
   @media (min-width: 700px) {
     .controls { grid-template-columns: 1fr 1fr 1fr; }
     .controls > .row:nth-child(1) { grid-column: 1 / -1; } /* arrows row spans full width */
@@ -113,6 +112,7 @@
       <div class="muted">Режим: <b id="modeText">Обычный</b></div>
     </div>
     <div class="toggles">
+      <label class="switch"><input id="toggleReverse" type="checkbox"><span>Перевод первым</span></label>
       <label class="switch"><input id="toggleBrowse" type="checkbox"><span>Пролистывание</span></label>
       <div class="seg" aria-label="Размер шрифта">
         <button id="fontDec" title="Уменьшить шрифт" aria-label="Уменьшить шрифт">A−</button>
@@ -150,7 +150,6 @@
     </div>
   </nav>
 
-  <footer>Данные карточек — в отдельном файле <code>cards/pronouns.js</code>. Цветовая схема — высококонтрастная, без «жёсткого» белого, для комфортного запоминания.</footer>
 </div>
 
 <div id="toast" class="toast"></div>


### PR DESCRIPTION
## Summary
- Add "Перевод первым" toggle to flashcards to show translation side first and reveal the front with hint on tap.
- Remove footer hints about where to place card data files across pages and drop instructions from main menu.

## Testing
- `node build.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68a4b717a3c8832290f29a0daf04a43f