### PR TITLE
Add rules-based trainer with inline answer input

### DIFF
--- a/cards/rules_adjectives.js
+++ b/cards/rules_adjectives.js
@@ -1,0 +1,325 @@
+window.RULES_PAYLOAD = {
+  id: 'adjectives_comparison',
+  title: 'Степени сравнения прилагательных',
+  rules: `
+  <div class="rule-container">
+    <h1>Степени сравнения польских прилагательных</h1>
+    <h2>Три степени сравнения (STOPIEŃ)</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Степень</th>
+          <th>Название</th>
+          <th>Пример</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Równy</td>
+          <td>Положительная</td>
+          <td>ciekawy</td>
+        </tr>
+        <tr>
+          <td>Wyższy</td>
+          <td>Сравнительная</td>
+          <td>ciekaw<span class="highlight">szy</span></td>
+        </tr>
+        <tr>
+          <td>Najwyższy</td>
+          <td>Превосходная</td>
+          <td><span class="highlight">naj</span>ciekawszy</td>
+        </tr>
+      </tbody>
+    </table>
+    <hr />
+    <h2>1. Регулярные прилагательные (REGULARNE)</h2>
+    <h3>Базовые окончания:</h3>
+    <ul>
+      <li><strong>na -szy</strong> → ciekawy → ciekaw<span class="highlight">szy</span> → <span class="highlight">naj</span>ciekawszy</li>
+      <li><strong>na -ejszy</strong> → nudny → nudn<span class="highlight">iejszy</span> → <span class="highlight">naj</span>nudniejszy</li>
+    </ul>
+    <h3>a) Чередование согласных (Wymiany spółgłosek)</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Чередование</th>
+          <th>Положительная</th>
+          <th>Сравнительная</th>
+          <th>Превосходная</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>m</strong> / <strong>mi</strong></td>
+          <td>uprzejmy</td>
+          <td>uprzej<span class="highlight">mi</span>ejszy</td>
+          <td>najuprzej<span class="highlight">mi</span>ejszy</td>
+        </tr>
+        <tr>
+          <td><strong>n</strong> / <strong>ń</strong></td>
+          <td>cienki</td>
+          <td>cie<span class="highlight">ń</span>szy</td>
+          <td>najcie<span class="highlight">ń</span>szy</td>
+        </tr>
+        <tr>
+          <td><strong>n</strong> / <strong>ni</strong></td>
+          <td>ładny</td>
+          <td>ład<span class="highlight">ni</span>ejszy</td>
+          <td>najład<span class="highlight">ni</span>ejszy</td>
+        </tr>
+        <tr>
+          <td><strong>r</strong> / <strong>rz</strong></td>
+          <td>mądry</td>
+          <td>mąd<span class="highlight">rz</span>ejszy</td>
+          <td>najmąd<span class="highlight">rz</span>ejszy</td>
+        </tr>
+        <tr>
+          <td><strong>l</strong> / <strong>l</strong></td>
+          <td>miły</td>
+          <td>mi<span class="highlight">l</span>szy</td>
+          <td>najmi<span class="highlight">l</span>szy</td>
+        </tr>
+        <tr>
+          <td><strong>g</strong> / <strong>ż</strong></td>
+          <td>drogi</td>
+          <td>dro<span class="highlight">ż</span>szy</td>
+          <td>najdro<span class="highlight">ż</span>szy</td>
+        </tr>
+        <tr>
+          <td><strong>s</strong> / <strong>ż</strong></td>
+          <td>bliski</td>
+          <td>bli<span class="highlight">ż</span>szy</td>
+          <td>najbli<span class="highlight">ż</span>szy</td>
+        </tr>
+        <tr>
+          <td><strong>st</strong> / <strong>ści</strong></td>
+          <td>gęsty</td>
+          <td>gę<span class="highlight">ści</span>ejszy</td>
+          <td>najgę<span class="highlight">ści</span>ejszy</td>
+        </tr>
+        <tr>
+          <td><strong>sn</strong> / <strong>śni</strong></td>
+          <td>jasny</td>
+          <td>ja<span class="highlight">śni</span>ejszy</td>
+          <td>najja<span class="highlight">śni</span>ejszy</td>
+        </tr>
+        <tr>
+          <td><strong>sl</strong> / <strong>śl</strong></td>
+          <td>dorosły</td>
+          <td>doro<span class="highlight">śl</span>ejszy</td>
+          <td>najdoro<span class="highlight">śl</span>ejszy</td>
+        </tr>
+      </tbody>
+    </table>
+    <h3>b) Чередование гласных (Wymiany samogłosek)</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>Чередование</th>
+          <th>Положительная</th>
+          <th>Сравнительная</th>
+          <th>Превосходная</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>a</strong> / <strong>e</strong></td>
+          <td>biały</td>
+          <td>bi<span class="highlight">e</span>lszy</td>
+          <td>najbi<span class="highlight">e</span>lszy</td>
+        </tr>
+        <tr>
+          <td><strong>o</strong> / <strong>e</strong></td>
+          <td>wesoły</td>
+          <td>wes<span class="highlight">e</span>lszy</td>
+          <td>najwes<span class="highlight">e</span>lszy</td>
+        </tr>
+        <tr>
+          <td><strong>ą</strong> / <strong>ę</strong></td>
+          <td>gorący</td>
+          <td>gor<span class="highlight">ę</span>tszy</td>
+          <td>najgor<span class="highlight">ę</span>tszy</td>
+        </tr>
+      </tbody>
+    </table>
+    <h3>c) Редукция (Redukcja)</h3>
+    <p>Выпадение части основы перед окончанием:</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Тип</th>
+          <th>Положительная</th>
+          <th>Сравнительная</th>
+          <th>Превосходная</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>-ki</strong></td>
+          <td>krót<span class="highlight">ki</span></td>
+          <td>krótszy</td>
+          <td>najkrótszy</td>
+        </tr>
+        <tr>
+          <td><strong>-oki</strong></td>
+          <td>szero<span class="highlight">ki</span></td>
+          <td>szerszy</td>
+          <td>najszerszy</td>
+        </tr>
+        <tr>
+          <td><strong>-eki</strong></td>
+          <td>dale<span class="highlight">ki</span></td>
+          <td>dalszy</td>
+          <td>najdalszy</td>
+        </tr>
+      </tbody>
+    </table>
+    <hr />
+    <h2>2. Нерегулярные прилагательные (NIEREGULARNE)</h2>
+    <p>Четыре важнейших исключения:</p>
+    <table class="irregular">
+      <thead>
+        <tr>
+          <th>Положительная</th>
+          <th>Сравнительная</th>
+          <th>Превосходная</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>dobry</strong> (хороший)</td>
+          <td><strong>lepszy</strong></td>
+          <td><strong>najlepszy</strong></td>
+        </tr>
+        <tr>
+          <td><strong>zły</strong> (плохой)</td>
+          <td><strong>gorszy</strong></td>
+          <td><strong>najgorszy</strong></td>
+        </tr>
+        <tr>
+          <td><strong>mały</strong> (маленький)</td>
+          <td><strong>mniejszy</strong></td>
+          <td><strong>najmniejszy</strong></td>
+        </tr>
+        <tr>
+          <td><strong>duży / wielki</strong> (большой)</td>
+          <td><strong>większy</strong></td>
+          <td><strong>największy</strong></td>
+        </tr>
+      </tbody>
+    </table>
+    <div class="rule-box">
+      <h2>📝 Основные правила</h2>
+      <ol>
+        <li><strong>Превосходная степень</strong> = <span class="highlight">naj</span> + сравнительная степень</li>
+        <li>Чередования применяются <strong>автоматически</strong> при добавлении окончаний</li>
+        <li>Окончание <strong>-ejszy</strong> используется после мягких согласных</li>
+        <li>Окончание <strong>-szy</strong> используется после твёрдых согласных</li>
+        <li>Нерегулярные прилагательные нужно <strong>заучивать наизусть</strong></li>
+      </ol>
+    </div>
+  </div>
+`,
+  words: [
+    { front: "Lublin jest ___________ (mały) miastem niż Wrocław.", back: "mniejszy" },
+    { front: "Tatry to ___________ (wysoki) góry w Polsce.", back: "najwyższe" },
+    { front: "Woda w Bałtyku jest ___________ (zimny) niż w Morzu Śródziemnym.", back: "zimniejsza" },
+    { front: "Toruń jest miastem ___________ (stary) nawet od Krakowa.", back: "starszym" },
+    { front: "Arkadius jest ___________ (kontrowersyjny) polskim projektantem mody.", back: "najbardziej kontrowersyjnym" },
+    { front: "Wisła jest ___________ (długi) polską rzeką.", back: "najdłuższą" },
+    { front: "Lech Wałęsa jest ___________ (znany) na świecie polskim laureatem Nagrody Nobla.", back: "najbardziej znanym" },
+    { front: "Warszawskie ulice są ___________ (szeroki) od krakowskich.", back: "szersze" },
+    { front: "Kościół Mariacki w Krakowie jest ___________ (wysoki) niż Sukiennice.", back: "wyższy" },
+    { front: "\\\"Nike\\\" jest ___________ (prestiżowy) nagrodą literacką w Polsce.", back: "najbardziej prestiżową" },
+    { front: "Sytuacja materialna mieszkańców wsi jest ___________ (zły) niż mieszkańców miast.", back: "gorsza" },
+    { front: "Ten film jest ___________ (ciekawy) niż poprzedni.", back: "ciekawszy" },
+    { front: "To jest ___________ (nudny) książka, jaką czytałem.", back: "najnudniejsza" },
+    { front: "Ona jest ___________ (uprzejmy) osobą w naszym biurze.", back: "najuprzejmiejszą" },
+    { front: "Ten materiał jest ___________ (cienki) od tamtego.", back: "cieńszy" },
+    { front: "Twój pokój jest ___________ (ładny) niż mój.", back: "ładniejszy" },
+    { front: "Einstein był ___________ (mądry) naukowcem swojej epoki.", back: "najmądrzejszym" },
+    { front: "To jest ___________ (miły) prezent, jaki dostałem.", back: "najmilszy" },
+    { front: "Złoto jest ___________ (drogi) niż srebro.", back: "droższe" },
+    { front: "Moja szkoła jest ___________ (bliski) niż twoja.", back: "bliższa" },
+    { front: "To jest ___________ (gęsty) las w okolicy.", back: "najgęstszy" },
+    { front: "Dzisiaj jest ___________ (jasny) dzień niż wczoraj.", back: "jaśniejszy" },
+    { front: "Mój brat jest ___________ (dorosły) ode mnie.", back: "dorosłszy" },
+    { front: "Śnieg jest ___________ (biały) niż mleko.", back: "bielszy" },
+    { front: "Klown był ___________ (wesoły) osobą na przyjęciu.", back: "najweselszą" },
+    { front: "Ta zupa jest ___________ (gorący) niż herbata.", back: "gorętsza" },
+    { front: "To jest ___________ (krótki) droga do centrum.", back: "najkrótsza" },
+    { front: "Ta ulica jest ___________ (szeroki) od poprzedniej.", back: "szersza" },
+    { front: "Księżyc jest ___________ (daleki) niż samolot.", back: "dalszy" },
+    { front: "Ten rok był ___________ (dobry) w moim życiu.", back: "najlepszy" },
+    { front: "Ta wiadomość jest ___________ (zły) niż myślałem.", back: "gorsza" },
+    { front: "To jest ___________ (mały) pudełko w sklepie.", back: "najmniejsze" },
+    { front: "Słoń jest ___________ (duży) niż koń.", back: "większy" },
+    { front: "Ta kawa jest ___________ (mocny) od tamtej.", back: "mocniejsza" },
+    { front: "On jest ___________ (silny) zawodnikiem w drużynie.", back: "najsilniejszym" },
+    { front: "To zadanie jest ___________ (słaby) niż poprzednie.", back: "słabsze" },
+    { front: "To jest ___________ (czysty) pokój w hotelu.", back: "najczystszy" },
+    { front: "Ulice są ___________ (brudny) po deszczu.", back: "brudniejsze" },
+    { front: "To jest ___________ (nowy) model telefonu.", back: "najnowszy" },
+    { front: "Ten budynek jest ___________ (stary) w mieście.", back: "najstarszy" },
+    { front: "Ona jest ___________ (młody) niż jej siostra.", back: "młodsza" },
+    { front: "Bill Gates jest ___________ (bogaty) niż ja.", back: "bogatszy" },
+    { front: "Ta rodzina jest ___________ (biedny) w naszej wsi.", back: "najbiedniejsza" },
+    { front: "Gepard jest ___________ (szybki) zwierzęciem na świecie.", back: "najszybszym" },
+    { front: "Żółw jest ___________ (wolny) od zająca.", back: "wolniejszy" },
+    { front: "Mount Everest jest ___________ (wysoki) górą na świecie.", back: "najwyższą" },
+    { front: "Ten dom jest ___________ (niski) od tego.", back: "niższy" },
+    { front: "Ta droga jest ___________ (długi) niż tamta.", back: "dłuższa" },
+    { front: "Te warzywa są ___________ (świeży) od tamtych.", back: "świeższe" },
+    { front: "Dzisiaj jest ___________ (ciepły) niż wczoraj.", back: "cieplej" },
+    { front: "Zima jest ___________ (zimny) porą roku.", back: "najzimniejszą" },
+    { front: "Diament jest ___________ (twardy) od szkła.", back: "twardszy" },
+    { front: "Poduszka jest ___________ (miękki) od krzesła.", back: "miększa" },
+    { front: "Piórko jest ___________ (lekki) od kamienia.", back: "lżejsze" },
+    { front: "To jest ___________ (ciężki) walizka.", back: "najcięższa" },
+    { front: "Ten człowiek jest ___________ (gruby) niż tamten.", back: "grubszy" },
+    { front: "Ta linia jest ___________ (cienki) od tamtej.", back: "cieńsza" },
+    { front: "To jest ___________ (szeroki) rzeka w Polsce.", back: "najszersza" },
+    { front: "Ta uliczka jest ___________ (wąski) w mieście.", back: "najwęższa" },
+    { front: "Szklanka jest ___________ (pełny) wody.", back: "pełna" },
+    { front: "Ten słoik jest ___________ (pusty) niż tamten.", back: "pustszy" },
+    { front: "Dzień jest ___________ (jasny) niż noc.", back: "jaśniejszy" },
+    { front: "Ta piwnica jest ___________ (ciemny) pomieszczeniem.", back: "najciemniejszym" },
+    { front: "Ten nóż jest ___________ (ostry) od tego.", back: "ostrzejszy" },
+    { front: "Ten ołówek jest ___________ (tępy) niż tamten.", back: "tępszy" },
+    { front: "Pustynia jest ___________ (suchy) niż las.", back: "suchsza" },
+    { front: "To jest ___________ (mokry) dzień w tym miesiącu.", back: "najmokrzejszy" },
+    { front: "Ta linia jest ___________ (prosty) niż tamta.", back: "prostsza" },
+    { front: "Ta droga jest ___________ (krzywy) od poprzedniej.", back: "krzywsza" },
+    { front: "To szkło jest ___________ (gładki) niż papier.", back: "gładsze" },
+    { front: "Ten materiał jest ___________ (szorstki) od jedwabiu.", back: "szorstszy" },
+    { front: "Ten las jest ___________ (gęsty) w regionie.", back: "najgęstszy" },
+    { front: "Jej włosy są ___________ (rzadki) niż moje.", back: "rzadsze" },
+    { front: "Ten nauczyciel jest ___________ (surowy) od tamtego.", back: "surowszy" },
+    { front: "To jest ___________ (dokładny) pomiar.", back: "najdokładniejszy" },
+    { front: "On jest ___________ (śmiały) żołnierzem w plutonie.", back: "najśmielszym" },
+    { front: "Ta kobieta jest ___________ (piękny) niż tamta.", back: "piękniejsza" },
+    { front: "To jest ___________ (brzydki) budynek w mieście.", back: "najbrzydszy" },
+    { front: "On jest ___________ (mądry) niż myślałem.", back: "mądrzejszy" },
+    { front: "To jest ___________ (głupi) pomysł, jaki słyszałem.", back: "najgłupszy" },
+    { front: "Ta droga jest ___________ (bezpieczny) od tamtej.", back: "bezpieczniejsza" },
+    { front: "To jest ___________ (niebezpieczny) miejsce w mieście.", back: "najniebezpieczniejsze" },
+    { front: "Ta herbata jest ___________ (słodki) niż kawa.", back: "słodsza" },
+    { front: "Ta cytryna jest ___________ (kwaśny) od pomarańczy.", back: "kwaśniejsza" },
+    { front: "Ten ser jest ___________ (słony) niż tamten.", back: "słoniejszy" },
+    { front: "Ta papryka jest ___________ (ostry) w sklepie.", back: "najostrzejsza" },
+    { front: "To jest ___________ (smaczny) potrawa na świecie.", back: "najsmaczniejsza" },
+    { front: "Ta historia jest ___________ (dziwny) niż poprzednia.", back: "dziwniejsza" },
+    { front: "To jest ___________ (normalny) sytuacja.", back: "normalna" },
+    { front: "On jest ___________ (szczęśliwy) człowiekiem, jakiego znam.", back: "najszczęśliwszym" },
+    { front: "Ta wiadomość jest ___________ (smutny) niż myślałem.", back: "smutniejsza" },
+    { front: "To jest ___________ (wesoły) film tego roku.", back: "najweselszy" },
+    { front: "Ta muzyka jest ___________ (głośny) od tamtej.", back: "głośniejsza" },
+    { front: "W bibliotece jest ___________ (cichy) niż na ulicy.", back: "ciszej" },
+    { front: "To jest ___________ (ważny) informacja.", back: "najważniejsza" },
+    { front: "Ta sprawa jest ___________ (pilny) od tamtej.", back: "pilniejsza" },
+    { front: "On jest ___________ (leniwy) studentem w klasie.", back: "najleniwszym" },
+    { front: "Ona jest ___________ (pracowity) niż jej kolega.", back: "pracowitszy" },
+    { front: "To jest ___________ (tani) sklep w okolicy.", back: "najtańszy" },
+    { front: "Ta restauracja jest ___________ (drogi) w mieście.", back: "najdroższa" }
+  ]
+};

--- a/main.js
+++ b/main.js
@@ -110,6 +110,12 @@ function renderMenu(){
         <li><a href="words.html?set=lem_1" style="font-weight:700; font-size:1.15rem; text-decoration:none; color:inherit;">Lem 1</a></li>
       </ul>
     </section>
+    <section>
+      <h2>Правила</h2>
+      <ul>
+        <li><a href="rules.html?set=adjectives_comparison" style="font-weight:700; font-size:1.15rem; text-decoration:none; color:inherit;">Степени сравнения прилагательных</a></li>
+      </ul>
+    </section>
   `;
 
   app.querySelectorAll('a[data-set]').forEach(link => {

--- a/rules.html
+++ b/rules.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+    <title>Правила и тренажёр</title>
+    <style>
+        :root{
+            --bg: #f7fafb;
+            --card: #ffffff;
+            --text: #0f172a;
+            --muted: #475569;
+            --primary: #4cc9f0;
+            --primary-600: #3bb9e3;
+            --accent: #ffd166;
+            --accent-600: #f7c548;
+            --ok: #22c55e;
+            --bad: #ef4444;
+            --shadow: 0 10px 30px rgba(2, 6, 23, .08);
+            --radius: 16px;
+        }
+        @media (prefers-color-scheme: dark){
+            :root{
+                --bg: #0b1220;
+                --card: #111827;
+                --text: #e5e7eb;
+                --muted: #9ca3af;
+                --shadow: 0 10px 30px rgba(0,0,0,.35);
+            }
+        }
+        html, body { height: 100%; }
+        body { font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, "Inter", "SF Pro", Arial, sans-serif; background: var(--bg); margin: 0; padding: 1.25rem; color: var(--text); }
+        #app { max-width: 980px; margin: auto; background: var(--card); border-radius: var(--radius); box-shadow: var(--shadow); padding: clamp(1rem, 3vw, 2rem); }
+        h1, h2, h3 { margin: 0 0 .4em; letter-spacing: .2px; }
+        p { color: var(--muted); }
+        button { font-size: 1rem; padding: .6rem 1rem; border-radius: 999px; border: 0; cursor: pointer; transition: transform .06s ease, box-shadow .2s ease, background .2s ease; }
+        button:active { transform: translateY(1px); }
+        .btn { background: #e2e8f0; color: #0f172a; }
+        .btn:hover { filter: brightness(0.98); }
+        .btn-primary { background: var(--primary); color: #062028; box-shadow: 0 6px 16px rgba(76,201,240,.25); }
+        .btn-primary:hover { background: var(--primary-600); }
+        .btn-accent { background: var(--accent); color: #3a2f00; box-shadow: 0 6px 16px rgba(255, 209, 102, .35); }
+        .btn-accent:hover { background: var(--accent-600); }
+        .btn-ok { background: var(--ok); color: #03210e; }
+        .btn-bad { background: var(--bad); color: #2a0b0b; }
+        input[type="text"], input[type="search"], input:not([type]) {
+            width: 100%; box-sizing: border-box; font-size: clamp(1rem, 2.4vw, 1.2rem); padding: .8rem 1rem; border-radius: 12px; border: 1px solid #cbd5e1; outline: none; background: #fff; color: var(--text);
+        }
+        input:focus { border-color: var(--primary); box-shadow: 0 0 0 4px rgba(76,201,240,.2); }
+        .topbar { display: flex; align-items: center; gap: .6rem; margin-bottom: 1rem; }
+        .topbar button { padding: .45rem .9rem; }
+        .practice-wrap { display: grid; grid-template-columns: 1fr; gap: 1rem; }
+        .card { position: relative; background: linear-gradient(180deg, #fff, #fbfdff); border: 1px solid #e2e8f0; border-radius: 20px; padding: clamp(14px, 3.5vw, 24px); box-shadow: var(--shadow); min-height: 160px; display: flex; flex-direction: column; justify-content: center; align-items: center; text-align: center; user-select: none; }
+        .card .label { color: var(--muted); font-size: .95rem; margin-bottom: .3rem; }
+        .card .task { font-size: clamp(1.1rem, 3.2vw, 1.6rem); font-weight: 650; }
+        .card .answer { font-size: clamp(1.4rem, 3.8vw, 1.9rem); font-weight: 800; letter-spacing: .3px; }
+        .tap-hint { margin-top: .5rem; font-size: .95rem; color: var(--muted); }
+        .choices { display: grid; grid-template-columns: 1fr 1fr; gap: .75rem; }
+        .feedback { min-height: 1.4rem; font-weight: 600; }
+        .feedback.ok { color: var(--ok); }
+        .feedback.bad { color: var(--bad); }
+        table { border-collapse: collapse; width: 100%; overflow: auto; display: block; }
+        th, td { padding: .4rem .6rem; border: 1px solid #e5e7eb; text-align: left; }
+        @media (max-width: 640px){
+            body { padding: .75rem; }
+            .choices { grid-template-columns: 1fr; }
+        }
+    </style>
+</head>
+<body>
+<div id="app"></div>
+<script src="wordtrainer.js"></script>
+<script src="rules.js"></script>
+</body>
+</html>

--- a/rules.js
+++ b/rules.js
@@ -1,0 +1,23 @@
+const ruleSets = {
+  adjectives_comparison: {
+    title: 'Степени сравнения прилагательных',
+    src: 'cards/rules_adjectives.js'
+  }
+};
+
+const params = new URLSearchParams(location.search);
+const key = params.get('set') || 'adjectives_comparison';
+const chosen = ruleSets[key] || ruleSets.adjectives_comparison;
+
+const script = document.createElement('script');
+script.src = chosen.src;
+script.onload = () => {
+  const payload = window.RULES_PAYLOAD || {};
+  const title = payload.title || chosen.title;
+  const words = payload.words || [];
+  const rules = payload.rules || '';
+  document.title = `Правила — ${title}`;
+  initWordTrainer({ title, words, rules, showRulesFirst: true });
+  window.RULES_PAYLOAD = undefined;
+};
+document.head.appendChild(script);

--- a/wordtrainer.js
+++ b/wordtrainer.js
@@ -1,4 +1,6 @@
 function initWordTrainer(set){
+  ensureTrainerStyles();
+
   const words = set.words || [];
   let order = words.map((_, i) => i);
   shuffle(order);
@@ -9,6 +11,11 @@ function initWordTrainer(set){
   let stats = order.map(i => ({ wi: i, attempts: 0, lastWrong: null }));
   const app = document.getElementById('app');
   let startTime = Date.now();
+  const hasRules = Boolean(set.rules);
+  const showRulesFirst = !!set.showRulesFirst && hasRules;
+  let stage = showRulesFirst ? 'intro' : 'practice';
+  let rulesVisible = false;
+  let answerValue = '';
 
   function calcStats(){
     const total = stats.length;
@@ -30,9 +37,40 @@ function initWordTrainer(set){
   }
 
   function render(){
+    if(stage === 'intro') return renderIntro();
+    return renderPractice();
+  }
+
+  function renderIntro(){
+    app.innerHTML = `
+      <div class="topbar"><button id="back" class="btn">← На главную</button></div>
+      <h2>${set.title}</h2>
+      <div class="rules-intro">
+        <div class="rules-scroll">${set.rules}</div>
+        <div class="rules-intro-actions">
+          <button id="start-learning" class="btn-primary">Обучение</button>
+        </div>
+      </div>
+    `;
+
+    document.getElementById('back').onclick = () => { window.location.href = 'index.html'; };
+    const startBtn = document.getElementById('start-learning');
+    if(startBtn){
+      startBtn.onclick = () => {
+        stage = 'practice';
+        rulesVisible = false;
+        start();
+      };
+    }
+  }
+
+  function renderPractice(){
     if(index >= order.length) return renderResults();
+
     const word = words[ order[index] ];
     const { total, known, unknown } = calcStats();
+    const hasInlineBlank = /_{3,}/.test(word.front || '');
+    const taskHtml = hasInlineBlank ? buildInlineTask(word.front) : escapeHtml(word.front);
 
     app.innerHTML = `
       <div class="topbar"><button id="back" class="btn">← На главную</button></div>
@@ -40,18 +78,19 @@ function initWordTrainer(set){
       <div class="practice-wrap">
         <div id="card" class="card" role="button" aria-pressed="${showAnswer}" tabindex="0">
           ${showAnswer
-            ? `<div><div class="label">Ответ</div><div class="answer">${word.back}</div><div class="tap-hint">Отметьте результат:</div></div>`
-            : `<div><div class="label">Переведите</div><div class="task">${word.front}</div><div class="tap-hint">Нажмите на карточку, чтобы увидеть ответ</div></div>`}
+            ? `<div><div class="label">Ответ</div><div class="answer">${escapeHtml(word.back)}</div><div class="tap-hint">Отметьте результат:</div></div>`
+            : `<div><div class="label">Переведите</div><div class="task">${taskHtml}</div><div class="tap-hint">Нажмите на карточку, чтобы увидеть ответ</div></div>`}
         </div>
         <div style="display:flex; gap:.5rem; margin:.6rem 0; flex-wrap:wrap;">
           <button type="button" id="btnPrev" class="btn" title="Назад">←</button>
           <button type="button" id="btnNext" class="btn" title="Вперёд">→</button>
         </div>
         <form id="answer-form" autocomplete="off">
-          <input id="answer" type="text" placeholder="Польский вариант" ${lastResult === false ? 'style="border:2px solid #ef4444"' : ''} />
+          <input id="answer" type="text" placeholder="Польский вариант" value="${escapeAttr(answerValue)}" ${lastResult === false ? 'style="border:2px solid #ef4444"' : ''} ${hasInlineBlank ? 'class="hidden-answer-input"' : ''} />
           <div style="display:flex; gap:.5rem; margin-top:.6rem; flex-wrap:wrap;">
             <button class="btn-primary">Проверить</button>
             <button type="button" id="toggle-hint" class="btn-accent">${showAnswer ? 'Скрыть ответ' : 'Показать ответ'}</button>
+            ${hasRules ? '<button type="button" id="view-rules" class="btn">Посмотреть правило</button>' : ''}
           </div>
         </form>
         ${showAnswer ? `<div class="choices" style="margin-top:.25rem;">
@@ -59,7 +98,7 @@ function initWordTrainer(set){
             <button id="btn-wrong" class="btn-bad">👎 Не угадал</button>
           </div>` : ''}
         <div id="feedback" class="feedback ${lastResult === true ? 'ok' : lastResult === false ? 'bad' : ''}">
-          ${lastResult === true ? 'Верно!' : lastResult === false && showAnswer ? `Неправильно. Ваш ответ был: - ${lastUserAnswer || ''} Попробуйте ещё или откройте ответ.` : ''}
+          ${lastResult === true ? 'Верно!' : lastResult === false && showAnswer ? `Неправильно. Ваш ответ был: - ${escapeHtml(lastUserAnswer || '')} Попробуйте ещё или откройте ответ.` : ''}
         </div>
         <div style="color:#64748b; display:flex; gap:.5rem; flex-wrap:wrap;">
           <div>Верно: <b>${known}</b></div>
@@ -68,16 +107,19 @@ function initWordTrainer(set){
         </div>
         <p style="color:#64748b">Задание ${index+1} из ${order.length}</p>
       </div>
+      ${hasRules && rulesVisible ? renderRulesOverlay() : ''}
     `;
 
     document.getElementById('back').onclick = () => { window.location.href = 'index.html'; };
 
     const formEl = document.getElementById('answer-form');
     const toggleHintBtn = document.getElementById('toggle-hint');
+    const inlineInput = document.getElementById('inline-answer');
     if(formEl){
       formEl.onsubmit = e => {
         e.preventDefault();
-        const userInput = formEl.answer.value.trim();
+        const inputNode = inlineInput ? inlineInput : formEl.answer;
+        const userInput = inputNode.value.trim();
         const userAns = userInput.toLowerCase();
         const stat = stats.find(s => s.wi === order[index]);
 
@@ -95,11 +137,23 @@ function initWordTrainer(set){
 
         lastResult = isOk;
         lastUserAnswer = userInput;
+        answerValue = isOk ? '' : userInput;
         showAnswer = !isOk;
 
         if(isOk) nextCard(); else render();
       };
       toggleHintBtn.onclick = e => { e.preventDefault(); showAnswer = !showAnswer; render(); };
+      if(inlineInput){
+        inlineInput.value = answerValue;
+        inlineInput.addEventListener('input', () => {
+          answerValue = inlineInput.value;
+          formEl.answer.value = inlineInput.value;
+        });
+      } else {
+        formEl.answer.addEventListener('input', () => {
+          answerValue = formEl.answer.value;
+        });
+      }
     }
 
     const card = document.getElementById('card');
@@ -130,7 +184,35 @@ function initWordTrainer(set){
       };
     }
 
-    setTimeout(() => { const ans = document.getElementById('answer'); if(ans) ans.focus(); }, 0);
+    const rulesBtn = document.getElementById('view-rules');
+    if(rulesBtn){
+      rulesBtn.onclick = e => { e.preventDefault(); rulesVisible = true; render(); };
+    }
+
+    if(rulesVisible){
+      const overlay = document.getElementById('rules-overlay');
+      const closeBtn = document.getElementById('close-rules');
+      if(closeBtn){
+        closeBtn.onclick = () => { rulesVisible = false; render(); };
+      }
+      if(overlay){
+        overlay.onclick = (event) => {
+          if(event.target === overlay){
+            rulesVisible = false;
+            render();
+          }
+        };
+      }
+    }
+
+    setTimeout(() => {
+      const inline = document.getElementById('inline-answer');
+      if(inline){ inline.focus(); }
+      else {
+        const ans = document.getElementById('answer');
+        if(ans) ans.focus();
+      }
+    }, 0);
   }
 
   function renderResults(){
@@ -138,7 +220,7 @@ function initWordTrainer(set){
     const errors = stats.filter(s => s.attempts > 1);
     const rows = [...stats].sort((a,b)=> b.attempts - a.attempts).map(s => {
       const w = words[s.wi];
-      return `<tr><td>${w.front} – ${w.back}</td><td>${s.lastWrong ? s.lastWrong : '-'}</td><td style="text-align:center;">${s.attempts}</td></tr>`;
+      return `<tr><td>${escapeHtml(w.front)} – ${escapeHtml(w.back)}</td><td>${s.lastWrong ? escapeHtml(s.lastWrong) : '-'}</td><td style="text-align:center;">${s.attempts}</td></tr>`;
     }).join('');
 
     const elapsed = Date.now() - startTime;
@@ -163,12 +245,22 @@ function initWordTrainer(set){
         ${errors.length ? '<button id="repeat-errors" class="btn-primary">Повторить только ошибочные</button>' : ''}
         <button id="repeat-all" class="btn-accent">Начать набор заново</button>
         <button id="to-menu" class="btn">К списку тренажёров</button>
+        ${hasRules ? '<button id="show-rules-again" class="btn">К правилам</button>' : ''}
       </div>
     `;
 
     document.getElementById('back').onclick = () => { start(); };
     document.getElementById('repeat-all').onclick = () => { start(); };
     document.getElementById('to-menu').onclick = () => { window.location.href = 'index.html'; };
+    const rulesBtn = document.getElementById('show-rules-again');
+    if(rulesBtn){
+      rulesBtn.onclick = () => {
+        if(hasRules){
+          stage = 'intro';
+          render();
+        }
+      };
+    }
     const rep = document.getElementById('repeat-errors');
     if(rep){
       rep.onclick = () => {
@@ -178,10 +270,26 @@ function initWordTrainer(set){
         showAnswer = false;
         lastResult = null;
         lastUserAnswer = null;
+        answerValue = '';
+        rulesVisible = false;
         startTime = Date.now();
         render();
       };
     }
+  }
+
+  function renderRulesOverlay(){
+    return `
+      <div class="rules-overlay" id="rules-overlay">
+        <div class="rules-dialog">
+          <div class="rules-dialog-header">
+            <h3>Правило</h3>
+            <button type="button" id="close-rules" aria-label="Закрыть" class="btn">×</button>
+          </div>
+          <div class="rules-dialog-body">${set.rules}</div>
+        </div>
+      </div>
+    `;
   }
 
   function nextCard(delay = 250){
@@ -189,6 +297,7 @@ function initWordTrainer(set){
     index++;
     showAnswer = false;
     lastUserAnswer = null;
+    answerValue = '';
     setTimeout(() => { lastResult = null; render(); }, delay);
   }
 
@@ -198,6 +307,7 @@ function initWordTrainer(set){
     showAnswer = false;
     lastResult = null;
     lastUserAnswer = null;
+    answerValue = '';
     render();
   }
 
@@ -210,6 +320,9 @@ function initWordTrainer(set){
     lastUserAnswer = null;
     stats = order.map(i => ({ wi: i, attempts: 0, lastWrong: null }));
     startTime = Date.now();
+    answerValue = '';
+    rulesVisible = false;
+    stage = 'practice';
     render();
   }
 
@@ -222,14 +335,114 @@ function initWordTrainer(set){
 
   function vibrate(ms){ if(navigator.vibrate) try{ navigator.vibrate(ms); } catch(e){} }
 
+  function escapeHtml(str){
+    if(str == null) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function escapeAttr(str){
+    return escapeHtml(str).replace(/`/g, '&#96;');
+  }
+
+  function buildInlineTask(text){
+    const safeParts = (text || '').split(/(_{3,})/);
+    return safeParts.map(part => {
+      if(/_{3,}/.test(part)){
+        return '<span class="inline-answer"><input id="inline-answer" type="text" placeholder="Ответ" value="' + escapeAttr(answerValue) + '" /></span>';
+      }
+      return escapeHtml(part);
+    }).join('');
+  }
+
+  function ensureTrainerStyles(){
+    if(document.getElementById('rules-trainer-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'rules-trainer-styles';
+    style.textContent = `
+      .hidden-answer-input{ display:none; }
+      .inline-answer input{
+        min-width: 140px;
+        padding: .25rem .5rem;
+        font-size: clamp(1rem, 2.4vw, 1.2rem);
+        border-radius: 8px;
+        border: 1px solid #cbd5e1;
+      }
+      .inline-answer input:focus{ border-color: var(--primary); box-shadow: 0 0 0 3px rgba(76,201,240,.2); outline:none; }
+      .rules-overlay{
+        position: fixed;
+        inset: 0;
+        background: rgba(15,23,42,.55);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        padding: 1.5rem;
+        z-index: 50;
+      }
+      .rules-dialog{
+        max-width: min(960px, 95vw);
+        max-height: min(90vh, 720px);
+        background: var(--card, #ffffff);
+        color: var(--text, #0f172a);
+        border-radius: 16px;
+        box-shadow: 0 30px 60px rgba(15,23,42,.35);
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      .rules-dialog-header{
+        display:flex;
+        align-items:center;
+        justify-content:space-between;
+        padding:.75rem 1rem;
+        border-bottom:1px solid rgba(148,163,184,.35);
+      }
+      .rules-dialog-header h3{ margin:0; font-size:1.1rem; }
+      .rules-dialog-body{
+        padding:1rem 1.25rem;
+        overflow:auto;
+        background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+      }
+      .rules-intro{ display:flex; flex-direction:column; gap:1rem; }
+      .rules-scroll{
+        max-height:min(70vh, 560px);
+        overflow:auto;
+        padding:1rem 1.25rem;
+        border-radius:16px;
+        background: linear-gradient(135deg, #f1f5f9 0%, #f8fafc 100%);
+        border:1px solid rgba(148,163,184,.3);
+      }
+      .rules-intro-actions{ display:flex; justify-content:flex-end; }
+      .rule-container h1{ text-align:center; color:#4c1d95; }
+      .rule-container h2{ color:#1d4ed8; border-bottom:2px solid rgba(59,130,246,.35); padding-bottom:.4rem; }
+      .rule-container table{ width:100%; border-collapse:collapse; margin:1rem 0; }
+      .rule-container th, .rule-container td{ border:1px solid rgba(148,163,184,.35); padding:.5rem .75rem; text-align:left; }
+      .rule-container tbody tr:nth-child(odd){ background:rgba(99,102,241,.05); }
+      .rule-container .irregular th{ background:#dc2626; color:#fff; }
+      .rule-container .irregular tr:nth-child(odd){ background:rgba(220,38,38,.1); }
+      .rule-container .highlight{ background:#fde68a; padding:0 .2rem; border-radius:4px; }
+      .rule-box{ background:linear-gradient(135deg, #e0f2fe 0%, #ede9fe 100%); border-left:4px solid #4f46e5; padding:1rem; border-radius:12px; }
+    `;
+    document.head.appendChild(style);
+  }
+
   window.addEventListener('keydown', (e) => {
+    if(stage !== 'practice' || rulesVisible) return;
     const tag = (e.target && e.target.tagName || '').toLowerCase();
     if(tag === 'input' || tag === 'textarea' || e.ctrlKey || e.metaKey || e.altKey) return;
     if(e.key === 'ArrowLeft'){ e.preventDefault(); prevCard(); }
     else if(e.key === 'ArrowRight'){ e.preventDefault(); nextCard(0); }
   });
 
-  start();
+  if(showRulesFirst){
+    render();
+  } else {
+    start();
+  }
 }
 
 window.initWordTrainer = initWordTrainer;


### PR DESCRIPTION
## Summary
- add a dedicated rules trainer page with shared styling and initial dataset for comparative adjectives
- extend the shared word trainer to support rule intros, rule overlays, and inline blanks rendered inside tasks
- expose the new rules section from the main menu alongside existing vocabulary trainers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f243f8cc548322940e5e2f96863510